### PR TITLE
ci: stop supporting go 1.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: go
 
 go:
-  - 1.2
   - "1.10"
   - tip


### PR DESCRIPTION
Hasn't been supported since commit
bf6f2387e1c14a6e5984f88a5359402a4afb8f13 since bufio.Reader.Discard
wasn't introduced until Go 1.5.