### PR TITLE
ref: simplify creation

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -26,9 +26,7 @@ type Reader struct {
 //
 // See `Default*` constants for default dialect used.
 func NewReader(r io.Reader) *Reader {
-	opts := Dialect{}
-	opts.setDefaults()
-	return NewDialectReader(r, opts)
+	return NewDialectReader(r, Dialect{})
 }
 
 // Create a custom CSV reader.

--- a/writer.go
+++ b/writer.go
@@ -22,12 +22,7 @@ type Writer struct {
 //
 // See `Default*` constants for default dialect used.
 func NewWriter(w io.Writer) Writer {
-	opts := Dialect{}
-	opts.setDefaults()
-	return Writer{
-		opts: opts,
-		w:    bufio.NewWriter(w),
-	}
+	return NewDialectWriter(w, Dialect{})
 }
 
 // Create a custom CSV writer.


### PR DESCRIPTION
* Delegate to a single function.
 * Avoid one unnecessary method call on creation for readers.